### PR TITLE
Remove deprecated bottle call

### DIFF
--- a/git-story.rb
+++ b/git-story.rb
@@ -8,8 +8,6 @@ class GitStory < Formula
 
   license "MIT"
 
-  bottle :unneeded
-
   def install
     bin.install "git-story-view"
     bin.install "git-story-open"


### PR DESCRIPTION
When updating homebrew currently, I get the warning:

Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the git-story-branch/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/git-story-branch/homebrew-tap/git-story.rb:11